### PR TITLE
sass checks if neutrino.options.config is defined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,13 +38,13 @@ function setupExtractText(neutrino, options) {
 };
 
 function setupSassModule(neutrino) {
-  const options = neutrino.options.config;
+  const config = neutrino.options.config;
   const sassOptions = {
     sourceMap: true
   };
 
-  if (options.resolve && options.resolve.modules) {
-    sassOptions.includePaths = options.resolve.modules;
+  if (config && config.resolve && config.resolve.modules) {
+    sassOptions.includePaths = config.resolve.modules;
   }
 
   neutrino.config.module


### PR DESCRIPTION
Presets started to fail with standard neutrino .eslintrc.js

(https://neutrino.js.org/middleware/neutrino-middleware-eslint/#eslintrc-config)

```
$ node ./node_modules/eslint/bin/eslint.js --print-config .
Cannot read config file: (...)/.eslintrc.js
Error: Cannot read property 'resolve' of undefined
TypeError: Cannot read config file: (...)/.eslintrc.js
Error: Cannot read property 'resolve' of undefined
    at setupSassModule ((...)/node_modules/neutrino-preset-pragmatic-react/src/index.js:46:14)
    at module.exports ((...)/node_modules/neutrino-preset-pragmatic-react/src/index.js:116:3)
    at use ((...)/node_modules/neutrino/src/api.js:106:40)
    at Array.map (native)
    at Object.<anonymous> ((...)/.eslintrc.js:7:4)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at module.exports ((...)/node_modules/require-uncached/index.js:28:9)
    at loadJSConfigFile ((...)/node_modules/eslint/lib/config/config-file.js:160:16)
    at loadConfigFile ((...)/node_modules/eslint/lib/config/config-file.js:215:22)
    at Object.load ((...)/node_modules/eslint/lib/config/config-file.js:535:18)
    at loadConfig ((...)/node_modules/eslint/lib/config.js:63:33)
    at getLocalConfig ((...)/node_modules/eslint/lib/config.js:130:29)
    at Config.getConfig ((...)/node_modules/eslint/lib/config.js:260:26)
    at CLIEngine.getConfigForFile ((...)/node_modules/eslint/lib/cli-engine.js:776:29)
    at Object.execute ((...)/node_modules/eslint/lib/cli.js:151:39)
    at Object.<anonymous> ((...)/node_modules/eslint/bin/eslint.js:74:28)
```